### PR TITLE
Be more consistent by not providing any group variables

### DIFF
--- a/backport.py
+++ b/backport.py
@@ -261,7 +261,8 @@ class InventoryCLI(CLI):
             results[group.name] = {}
             if group.name != 'all':
                 results[group.name]['hosts'] = [h.name for h in sorted(group.hosts, key=attrgetter('name'))]
-            results[group.name]['vars'] = group.get_vars()
+            # NOTE: vars are not added, because vars in group_vars files can not be obtained
+            # results[group.name]['vars'] = group.get_vars()
             results[group.name]['children'] = []
             for subgroup in sorted(group.child_groups, key=attrgetter('name')):
                 results[group.name]['children'].append(subgroup.name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+import pytest
+import mock
+
+import os
+import sys
+import json
+
+import argparse
+
+
+# Add awx/plugins to sys.path so we can use the plugin
+TEST_DIR = os.path.dirname(__file__)
+path = os.path.abspath(os.path.join(TEST_DIR, '..'))
+if path not in sys.path:
+    sys.path.insert(0, path)
+
+# Backported ansible-inventory plugin
+from backport import InventoryCLI  # noqa
+
+
+@pytest.fixture()
+def command():
+    def make_command(args):
+        instance = InventoryCLI(args)
+        instance.options = argparse.ArgumentParser(description='Process some integers.')
+        instance.options.verbosity = 0
+        instance.options.vault_password_file = None
+        instance.options.ask_vault_pass = False
+        instance.options.inventory = __file__
+        instance.options.host = None
+        instance.options.graph = False
+        instance.options.list = True
+        instance.options.yaml = False
+        return instance
+    return make_command
+
+
+@pytest.fixture
+def get_output():
+    def ret(instance):
+        # Run command and return output
+        with mock.patch('backport.display') as mock_display:
+            mock_display_method = mock.MagicMock()
+            mock_display.display = mock_display_method
+            with pytest.raises(SystemExit):
+                instance.run()
+            mock_display_method.assert_called()
+            output = mock_display_method.mock_calls[0][1][0]
+            output = json.loads(output)
+        return output
+    return ret

--- a/tests/data/bug_gv/README.md
+++ b/tests/data/bug_gv/README.md
@@ -1,0 +1,43 @@
+### Reported Issue
+
+Group vars provided inside of the inventory file are returned inside
+of the group, but those provided inside of a group_vars folder are not.
+Run the `inventory.ini` file for an example:
+
+`./backport.py -i tests/data/bug_gv/inventory.ini --list`
+
+```json
+{
+    "_meta": {
+        "hostvars": {
+            "host_inside_group": {
+                "agroup_var_from_group_vars_file": true, 
+                "agroup_var_from_inventory_file": true
+            }
+        }
+    }, 
+    "agroup": {
+        "hosts": [
+            "host_inside_group"
+        ], 
+        "vars": {
+            "agroup_var_from_inventory_file": true
+        }
+    }, 
+    "all": {
+        "children": [
+            "agroup", 
+            "ungrouped"
+        ]
+    }, 
+    "ungrouped": {
+        "hosts": [
+            "host_inside_group"
+        ]
+    }
+}
+```
+
+Both variables are correctly set on the host, but the variable
+`agroup_var_from_inventory_file` is also provided on the group,
+which is inconsistent.

--- a/tests/data/bug_gv/group_vars/agroup
+++ b/tests/data/bug_gv/group_vars/agroup
@@ -1,0 +1,1 @@
+agroup_var_from_group_vars_file: True

--- a/tests/data/bug_gv/inventory.ini
+++ b/tests/data/bug_gv/inventory.ini
@@ -1,0 +1,7 @@
+host_inside_group
+
+[agroup]
+host_inside_group
+
+[agroup:vars]
+agroup_var_from_inventory_file=True

--- a/tests/test_no_group_vars.py
+++ b/tests/test_no_group_vars.py
@@ -1,0 +1,18 @@
+import os
+
+# Backported ansible-inventory plugin
+from backport import InventoryCLI  # noqa
+
+
+TEST_DIR = os.path.dirname(__file__)
+EXAMPLE_FILE = os.path.join(TEST_DIR, 'data', 'bug_gv', 'inventory.ini')
+
+
+def test_no_group_vars(command, get_output):
+    instance = command(['-i', EXAMPLE_FILE, '--list'])
+    instance.options.inventory = EXAMPLE_FILE
+    output = get_output(instance)
+    assert 'vars' not in output['agroup']
+    hvars = output['_meta']['hostvars']['host_inside_group']
+    assert 'agroup_var_from_inventory_file' in hvars
+    assert 'agroup_var_from_group_vars_file' in hvars

--- a/tests/test_static_files.py
+++ b/tests/test_static_files.py
@@ -1,17 +1,4 @@
 import pytest
-import mock
-import json
-
-# python
-import os
-import sys
-import argparse
-
-# Add awx/plugins to sys.path so we can use the plugin
-TEST_DIR = os.path.dirname(__file__)
-path = os.path.abspath(os.path.join(TEST_DIR, '..'))
-if path not in sys.path:
-    sys.path.insert(0, path)
 
 # Backported ansible-inventory plugin
 from backport import InventoryCLI  # noqa
@@ -66,75 +53,44 @@ def ini_file(test_dir):
     return fn
 
 
-@pytest.fixture()
-def command():
-    def make_command(args):
-        instance = InventoryCLI(args)
-        instance.options = argparse.ArgumentParser(description='Process some integers.')
-        instance.options.verbosity = 0
-        instance.options.vault_password_file = None
-        instance.options.ask_vault_pass = False
-        instance.options.inventory = __file__
-        instance.options.host = None
-        instance.options.graph = False
-        instance.options.list = True
-        instance.options.yaml = False
-        return instance
-    return make_command
-
-
 class TestLoadFile:
 
-    def get_output(self, instance):
-        # Run command and return output
-        with mock.patch('backport.display') as mock_display:
-            mock_display_method = mock.MagicMock()
-            mock_display.display = mock_display_method
-            with pytest.raises(SystemExit):
-                instance.run()
-            mock_display_method.assert_called()
-            output = mock_display_method.mock_calls[0][1][0]
-            output = json.loads(output)
-        return output
-
-    def test_host_and_group_vars(self, ini_file, command):
+    def test_host_and_group_vars(self, ini_file, command, get_output):
         instance = command(['-i', ini_file.dirname, '--list'])
         instance.options.inventory = ini_file.dirname
-        output = self.get_output(instance)
+        output = get_output(instance)
         # Test vars set on hosts individually
         assert output['_meta']['hostvars']['web1.example.com']['ansible_ssh_host'] == 'w1.example.net'
-        # Test vars set on a group
-        assert output['dbservers']['vars']['dbvar'] == 'ugh'
 
-    def test_inventory_import_group_vars_file(self, ini_file, tmpdir_factory, command):
+    def test_inventory_import_group_vars_file(self, ini_file, tmpdir_factory, command, get_output):
         # Create an extra group_vars file for group webservers
         f = tmpdir_factory.mktemp('inv_files/group_vars', numbered=False).join('webservers')
         f.write('''webservers_only_variable: foobar\n''')
 
         instance = command(['-i', ini_file.dirname, '--list'])
         instance.options.inventory = ini_file.dirname
-        output = self.get_output(instance)
+        output = get_output(instance)
 
         for host in ['web1.example.com', 'web2.example.com', 'web3.example.com']:
             assert output['_meta']['hostvars'][host]['webservers_only_variable'] == 'foobar'
 
-    def test_inventory_import_host_vars_file(self, ini_file, tmpdir_factory, command):
+    def test_inventory_import_host_vars_file(self, ini_file, tmpdir_factory, command, get_output):
         # Create an extra group_vars file for group webservers
         f = tmpdir_factory.mktemp('inv_files/host_vars', numbered=False).join('db1.example.com')
         f.write('''database_only: foobar\n''')
 
         instance = command(['-i', ini_file.dirname, '--list'])
         instance.options.inventory = ini_file.dirname
-        output = self.get_output(instance)
+        output = get_output(instance)
 
         assert output['_meta']['hostvars']['db1.example.com']['database_only'] == 'foobar'
 
-    def test_ansible_facts_not_in_hostvars(self, test_dir, command):
+    def test_ansible_facts_not_in_hostvars(self, test_dir, command, get_output):
         fn = test_dir.join('test_hosts')
         fn.write('''foo.bar.com\n''')
 
         instance = command(['-i', fn.dirname, '--list'])
         instance.options.inventory = fn.dirname
-        output = self.get_output(instance)
+        output = get_output(instance)
 
         assert 'ansible_facts' not in output['_meta']['hostvars']['foo.bar.com']


### PR DESCRIPTION
Put in a change to no longer apply group vars to groups in the output. This will resolve the inconsistency, even though it is taking something away.