### PR TITLE
Import newer changes from ansible-inventory that are backward compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "2.7"
 
 env:
-  - ANSIBLE_VERSION="ansible==2.2"
-  - ANSIBLE_VERSION="ansible==2.3"
+  - ANSIBLE_VERSION="ansible==2.2.3"
+  - ANSIBLE_VERSION="ansible==2.3.1"
   - ANSIBLE_VERSION="git+https://github.com/ansible/ansible.git@devel"
 
 install:

--- a/backport.py
+++ b/backport.py
@@ -22,13 +22,9 @@ __metaclass__ = type
 import optparse
 from operator import attrgetter
 
-from ansible import constants as C
 from ansible.cli import CLI
 from ansible.errors import AnsibleOptionsError
-from ansible.inventory import Inventory
 from ansible.parsing.dataloader import DataLoader
-from ansible.vars import VariableManager
-
 
 try:
     from __main__ import display
@@ -47,21 +43,24 @@ INTERNAL_VARS = frozenset([ 'ansible_facts',
                             'group_names',
                             'omit',
                             'playbook_dir',
-                            ])
-
+                         ])
 
 class InventoryCLI(CLI):
     ''' used to display or dump the configured inventory as Ansible sees it '''
 
     ARGUMENTS = { 'host': 'The name of a host to match in the inventory, relevant when using --list',
                   'group': 'The name of a group in the inventory, relevant when using --graph',
-                  }
+    }
 
     def __init__(self, args):
 
         super(InventoryCLI, self).__init__(args)
+        self.args = args
         self.vm = None
         self.loader = None
+        self.inventory = None
+
+        self._new_api = True
 
     def parse(self):
 
@@ -71,10 +70,12 @@ class InventoryCLI(CLI):
             inventory_opts=True,
             vault_opts=True
         )
+        self.parser.add_option("--optimize", action="store_true", default=False, dest='optimize',
+                               help='Output variables on the group or host where they are defined')
 
         # Actions
         action_group = optparse.OptionGroup(self.parser, "Actions", "One of following must be used on invocation, ONLY ONE!")
-        action_group.add_option("--list", action="store_true", default=False, dest='list', help='Output all hosts info, works as inventory script')
+        action_group.add_option("--list", action="store_true", default=False,dest='list', help='Output all hosts info, works as inventory script')
         action_group.add_option("--host", action="store", default=None, dest='host', help='Output specific host info, works as inventory script')
         action_group.add_option("--graph", action="store_true", default=False, dest='graph',
                                 help='create inventory graph, if supplying pattern it must be a valid group name')
@@ -93,32 +94,6 @@ class InventoryCLI(CLI):
                 raise
             # --- Start of 2.3+ super(InventoryCLI, self).parse() ---
             self.options, self.args = self.parser.parse_args(self.args[1:])
-            if hasattr(self.options, 'tags') and not self.options.tags:
-                # optparse defaults does not do what's expected
-                self.options.tags = ['all']
-            if hasattr(self.options, 'tags') and self.options.tags:
-                if not C.MERGE_MULTIPLE_CLI_TAGS:
-                    if len(self.options.tags) > 1:
-                        display.deprecated('Specifying --tags multiple times on the command line currently uses the last specified value. In 2.4, values will be merged instead.  Set merge_multiple_cli_tags=True in ansible.cfg to get this behavior now.', version=2.5, removed=False)
-                        self.options.tags = [self.options.tags[-1]]
-
-                tags = set()
-                for tag_set in self.options.tags:
-                    for tag in tag_set.split(u','):
-                        tags.add(tag.strip())
-                self.options.tags = list(tags)
-
-            if hasattr(self.options, 'skip_tags') and self.options.skip_tags:
-                if not C.MERGE_MULTIPLE_CLI_TAGS:
-                    if len(self.options.skip_tags) > 1:
-                        display.deprecated('Specifying --skip-tags multiple times on the command line currently uses the last specified value. In 2.4, values will be merged instead.  Set merge_multiple_cli_tags=True in ansible.cfg to get this behavior now.', version=2.5, removed=False)
-                        self.options.skip_tags = [self.options.skip_tags[-1]]
-
-                skip_tags = set()
-                for tag_set in self.options.skip_tags:
-                    for tag in tag_set.split(u','):
-                        skip_tags.add(tag.strip())
-                self.options.skip_tags = list(skip_tags)
             # --- End of 2.3+ super(InventoryCLI, self).parse() ---
 
         display.verbosity = self.options.verbosity
@@ -148,39 +123,48 @@ class InventoryCLI(CLI):
         super(InventoryCLI, self).run()
 
         # Initialize needed objects
-        self.loader = DataLoader()
-        self.vm = VariableManager()
-
-        # use vault if needed
-        if self.options.vault_password_file:
-            vault_pass = CLI.read_vault_password_file(self.options.vault_password_file, loader=self.loader)
-        elif self.options.ask_vault_pass:
-            vault_pass = self.ask_vault_passwords()
+        if getattr(self, '_play_prereqs', False):
+            self.loader, self.inventory, self.vm = self._play_prereqs(self.options)
         else:
-            vault_pass = None
+            # fallback to pre 2.4 way of initialzing
+            from ansible.vars import VariableManager
+            from ansible.inventory import Inventory
 
-        if vault_pass:
-            self.loader.set_vault_password(vault_pass)
+            self._new_api = False
+            self.loader = DataLoader()
+            self.vm = VariableManager()
 
-        # actually get inventory and vars
-        self.inventory = Inventory(loader=self.loader, variable_manager=self.vm, host_list=self.options.inventory)
-        self.vm.set_inventory(self.inventory)
+            # use vault if needed
+            if self.options.vault_password_file:
+                vault_pass = CLI.read_vault_password_file(self.options.vault_password_file, loader=self.loader)
+            elif self.options.ask_vault_pass:
+                vault_pass = self.ask_vault_passwords()
+            else:
+                vault_pass = None
+
+            if vault_pass:
+                self.loader.set_vault_password(vault_pass)
+                # actually get inventory and vars
+
+            self.inventory = Inventory(loader=self.loader, variable_manager=self.vm, host_list=self.options.inventory)
+            self.vm.set_inventory(self.inventory)
+
 
         if self.options.host:
             hosts = self.inventory.get_hosts(self.options.host)
             if len(hosts) != 1:
                 raise AnsibleOptionsError("You must pass a single valid host to --hosts parameter")
 
-            myvars = self.vm.get_vars(self.loader, host=hosts[0])
+            myvars = self._get_host_variables(host=hosts[0])
             self._remove_internal(myvars)
 
-            # FIXME: should we template first?
+            #FIXME: should we template first?
             results = self.dump(myvars)
 
         elif self.options.graph:
             results = self.inventory_graph()
         elif self.options.list:
-            top = self.inventory.get_group('all')
+            top = self._get_group('all')
             if self.options.yaml:
                 results = self.yaml_inventory(top)
             else:
@@ -188,6 +172,7 @@ class InventoryCLI(CLI):
             results = self.dump(results)
 
         if results:
+            #FIXME: pager?
             display.display(results)
             exit(0)
 
@@ -204,6 +189,20 @@ class InventoryCLI(CLI):
             results = json.dumps(stuff, sort_keys=True, indent=4)
 
         return results
+
+    def _get_host_variables(self, host):
+        if self._new_api:
+           hostvars =  self.vm.get_vars(host=host)
+        else:
+           hostvars =  self.vm.get_vars(self.loader, host=host)
+        return hostvars
+
+    def _get_group(self, gname):
+        if self._new_api:
+            group = self.inventory.groups.get(gname)
+        else:
+            group = self.inventory.get_group(gname)
+        return group
 
     def _remove_internal(self, dump):
 
@@ -248,7 +247,7 @@ class InventoryCLI(CLI):
 
     def inventory_graph(self):
 
-        start_at = self.inventory.get_group(self.options.pattern)
+        start_at = self._get_group(self.options.pattern)
         if start_at:
             return '\n'.join(self._graph_group(start_at))
         else:
@@ -276,7 +275,7 @@ class InventoryCLI(CLI):
         results['_meta'] = {'hostvars': {}}
         hosts = self.inventory.get_hosts()
         for host in hosts:
-            results['_meta']['hostvars'][host.name] = self.vm.get_vars(self.loader, host=host)
+            results['_meta']['hostvars'][host.name] = self._get_host_variables(host=host)
             self._remove_internal(results['_meta']['hostvars'][host.name])
 
         return results
@@ -305,7 +304,7 @@ class InventoryCLI(CLI):
                     myvars = {}
                     if h.name not in seen:  # avoid defining host vars more than once
                         seen.append(h.name)
-                        myvars = self.vm.get_vars(self.loader, host=h)
+                        myvars = self._get_host_variables(host=h)
                         self._remove_internal(myvars)
                     results[group.name]['hosts'][h.name] = myvars
 

--- a/tests/data/everything/group_vars/group_1
+++ b/tests/data/everything/group_vars/group_1
@@ -1,0 +1,1 @@
+groupvar_file: defined_in_group_vars

--- a/tests/data/everything/host_vars/host_1
+++ b/tests/data/everything/host_vars/host_1
@@ -1,0 +1,1 @@
+hostvar_file: defined_in_host_vars

--- a/tests/data/everything/inventory.ini
+++ b/tests/data/everything/inventory.ini
@@ -1,0 +1,15 @@
+host_ungrouped
+host_1 hostvar_inventory=defined_in_inventory_file
+host_2
+
+[group_1]
+host_1
+
+[group_2]
+host_2
+
+[group_1:children]
+group_2
+
+[group_1:vars]
+groupvar_inventory=defined_in_inventory_file

--- a/tests/test_local_formatting.py
+++ b/tests/test_local_formatting.py
@@ -1,0 +1,59 @@
+import pytest
+import mock
+import json
+
+# python
+import os
+import sys
+import argparse
+import cStringIO
+
+# Add awx/plugins to sys.path so we can use the plugin
+TEST_DIR = os.path.dirname(__file__)
+path = os.path.abspath(os.path.join(TEST_DIR, '..'))
+if path not in sys.path:
+    sys.path.insert(0, path)
+
+# Backported ansible-inventory plugin
+from backport import InventoryCLI  # noqa
+
+# Primary version of ansible-inventory
+try:
+    from ansible.cli.inventory import InventoryCLI as ansible_CLI
+except ImportError:
+    ansible_CLI = None
+
+
+TEST_DIR = os.path.dirname(__file__)
+EXAMPLE_FILE = os.path.join(TEST_DIR, 'data', 'everything', 'inventory.ini')
+
+
+@pytest.mark.skipif(ansible_CLI is None, reason="Only testing post-2.4 behavior")
+def test_full_group_vars():
+    run = ansible_CLI(['ansible-inventory', '-i', EXAMPLE_FILE, '--local', '--list'])
+    run.parse()
+    stdout_ = sys.stdout
+    stream = cStringIO.StringIO()
+    try:
+        sys.stdout = stream
+        run.run()
+    except SystemExit:
+        pass
+    finally:
+        sys.stdout = stdout_
+        output = stream.getvalue()
+    inv_dict = json.loads(output)
+    assert 'group_2' in inv_dict
+    assert '_meta' in inv_dict
+    assert 'hostvars' in inv_dict['_meta']
+    assert set(['host_1', 'host_2', 'host_ungrouped']) == set(inv_dict['_meta']['hostvars'].keys())
+    assert {} == inv_dict['_meta']['hostvars']['host_2'] == inv_dict['_meta']['hostvars']['host_ungrouped']
+    assert {
+        "hostvar_inventory": "defined_in_inventory_file",
+        "hostvar_file": "defined_in_host_vars"
+    } == inv_dict['_meta']['hostvars']['host_1']
+    assert {
+        "groupvar_file": "defined_in_group_vars", 
+        "groupvar_inventory": "defined_in_inventory_file"
+    } == inv_dict['group_1']['vars']
+

--- a/tests/test_static_files.py
+++ b/tests/test_static_files.py
@@ -24,15 +24,7 @@ EXAMPLE_FILE = os.path.join(TEST_DIR, 'data', 'legacy', 'inventory.ini')
 def command():
     def make_command(args):
         instance = InventoryCLI(args)
-        instance.options = argparse.ArgumentParser(description='Process some integers.')
-        instance.options.verbosity = 0
-        instance.options.vault_password_file = None
-        instance.options.ask_vault_pass = False
-        instance.options.inventory = __file__
-        instance.options.host = None
-        instance.options.graph = False
-        instance.options.list = True
-        instance.options.yaml = False
+        instance.parse()
         return instance
     return make_command
 


### PR DESCRIPTION
This entire repo might be unnecessary soon, since the main ansible-inventory PR has added some backward-compatible support.

This is almost strictly a copy+paste of that with 1 small change, will submit to upstream.

Tests pass with 2.3, need to test 2.2.