### PR TITLE
remove local flag from 2.4 tests

### DIFF
--- a/tests/test_local_formatting.py
+++ b/tests/test_local_formatting.py
@@ -28,7 +28,7 @@ EXAMPLE_FILE = os.path.join(TEST_DIR, 'data', 'everything', 'inventory.ini')
 
 @pytest.mark.skipif(ansible_CLI is None, reason="Only testing post-2.4 behavior")
 def test_full_group_vars():
-    run = ansible_CLI(['ansible-inventory', '-i', EXAMPLE_FILE, '--local', '--list'])
+    run = ansible_CLI(['ansible-inventory', '-i', EXAMPLE_FILE, '--list'])
     run.parse()
     stdout_ = sys.stdout
     stream = cStringIO.StringIO()


### PR DESCRIPTION
This will fail the tests, but these will be meaningful tests, indicating the the optimized version is not there yet.